### PR TITLE
adds imports that work on python 3

### DIFF
--- a/simulacrum/__init__.py
+++ b/simulacrum/__init__.py
@@ -5,5 +5,5 @@ import numpy as np
 from datetime import datetime
 
 from .dataset import DataSet
-from simdata import *
-from coltypes import ColTypes
+from .simdata import create
+from .coltypes import ColTypes


### PR DESCRIPTION
This addresses #7. Python 3 does not allow relative imports anymore.
