### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,32 +13,52 @@ present but the company may have a general understanding of the shape of this da
 trained on this simulated data and a machine learning application can be developed in parallel to gathering real data! This
 hopefully engineers scalability and foresight for companies with slow data velocity.
 
-### Installation
+## Installation
 
 ```
 $ pip install simulacrum
 ```
 
-### Usage
-To create a fake pandas dataframe consisting of 100 rows. we would do the following:
+## Usage
 ```python
->>> import simulacrum as sm
->>> test = {'entries': {'type': 'exp', 'lam': 0.5},
-...        'names': {'type': 'name'},
-...        'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
+import simulacrum as sm
+types = {
+    'entries': {'type': 'exp', 'lam': 0.5},
+    'names': {'type': 'name'},
+    'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
 
->>> res = sm.create(100, coltypes=test)
+res = sm.create(length=100, coltypes=types)
+print(res.head())
 
+#     entries           names       salaries
+# 0  0.453003    Terri Fisher   65471.389461
+# 1  0.247907    William West   53718.937276
+# 2  2.637221    John Johnson   52750.467547
+# 3  1.403986       Nancy Kim   50436.549855
+# 4  0.437987  Jennifer Moses  116760.941144
 ```
-For the test variable which will be passed as coltypes, each key corresponds to the column name. Each value must be a dictionary
-with one key being type and then whatever statistical parameters if any correspond to that type. Please review source code to
-see how to properly pass the correct keys and values. Possible types are as follows:
+The `coltypes` parameter is a dict, where the keys are column names, and the
+values are dicts with keys `type` and then whatever parameters the type takes. 
+Please review source code to see how to properly pass the correct keys and
+values. Possible values for the `type` parameter are as follows:
 
-`{'num': num_data, 'int': num_int, 'norm': norm_data, 'exp': exp_data, 'bin': binom_data, 'pois': poisson_data, 'txt': text_data, 'name': name_data, 'addr': address_data, 'date': date_data, 'coords': coords_data, 'uuid': uuid_data, 'faker': faker_data}`
+type|Description|Parameters
+---|---|---
+num|Random floats from a uniform distribution|`min=0`, `max=1`
+int|Random integers from a uniform distribution|`min=0`, `max=100`
+norm|Random floats from a normal distribution|`mean=0`, `sd=1`
+exp|Random floats from an exponential distribution|`lam=1.0`
+bin|Random integers from a binomial distribution|`n=100`,`p=0.1`
+pois|Random integers from a Poisson distribution|`lam=1.0`
+txt|Faker text - sequences of lorem ipsum-style text|`max_nb_chars=200`
+name|Faker name - random full names|
+addr|Faker address - random full addresses|
+date|Dates between begin and end.  If no begin/end are provided, default to the past year.|`begin=None`, `end=None`, `tzinfo=None`
+coords|Random tuples of floats from uniform 2D distribution|`lat_min=-90`, `lat_max=90`, `lon_min=-180`, `lon_max=180`
+uuid|Randomly selected UUIDs|
+faker|Custom faker field - see below|`provider`, `kwargs`
 
-Each key corresponds to a possible type, and the value is the function called in the source.
-
-We can also use the ColTypes class to create the coltypes dict with function calls.
+We can also use the ColTypes class to create the coltypes dict with function calls:
 
 ```python
 
@@ -53,7 +73,7 @@ col_types.add_coltype('ips', 'faker', provider='ipv6')
 data_set = sm.create(1000, coltypes=col_types.get_coltypes())
 ```
 
-For a quick demonstration, if you don't specify any types a dataframe is created with one of each of the available types:
+If you don't specify any types, a dataframe is created with one of each of the available types:
 
 ```python
 import simulacrum as sm
@@ -74,37 +94,33 @@ list(df.iterrows())[0][1]
 #Name: 0, dtype: object
 ```
 
-#### faker type:
+### Faker type
 
-If you want to use other data types not allowed in simulacrum by default, you can use the `faker` type to use each data type provided by the awesome faker library.
+If you want to use other data types not allowed in simulacrum by default, you can use the `faker` type to use each data type provided by the awesome faker library: https://faker.readthedocs.io/en/latest/providers.html
 
-**List of faker data types : https://faker.readthedocs.io/en/latest/providers.html**
-
-To use the faker type, you have to pass the provider name and optional args like that:
+To use the faker type, you must pass the provider name and optional args like:
 
 ```python
 faker_examples = {
-        # same as fake.simple_profile(sex='F')
-        'names': {'type': 'faker', 'provider': 'simple_profile', 'sex': 'F'},
-        # same as fake.ipv6()
-        'ips': {'type': 'faker', 'provider': 'ipv6'},
-        # same as fake.job()
-        'jobs': {'type': 'faker', 'provider': 'job'},
-        # same as fake.pydict(nb_elements=10, variable_nb_elements=True)
-        'metadata': {'type': 'faker', 'provider': 'pydict', 'nb_elements': 10, 'variable_nb_elements': True}
+    # same as fake.simple_profile(sex='F')
+    'names': {'type': 'faker', 'provider': 'simple_profile', 'sex': 'F'},
+    # same as fake.ipv6()
+    'ips': {'type': 'faker', 'provider': 'ipv6'},
+    # same as fake.job()
+    'jobs': {'type': 'faker', 'provider': 'job'},
+    # same as fake.pydict(nb_elements=10, variable_nb_elements=True)
+    'metadata': {'type': 'faker', 'provider': 'pydict', 'nb_elements': 10, 'variable_nb_elements': True},
+    'zips': {'type': 'faker', 'provider': 'zipcode'}
 }
+df = sm.create(coltypes=faker_examples)
 
 # Or with ColTypes
 col_types.add_coltype('ids', 'faker', provider='pydict', nb_elements=10, variable_nb_elements=True)
 ```
 
 ### TODO
-- Add a error handling and validation for date_data function
-- Add a function for fake coordinates
-- Add a function for fake zipcodes
 - Add a function for fake categorical variables
-- Add Try Except blocks to all functions to log errors when params passed in dict dont match expected params
-
+- Handle random seeds some way
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To create a fake pandas dataframe consisting of 100 rows. we would do the follow
 
 import simulacrum as sm
 
-test = {'entries': {'type': 'exp', 'scale': 0.5},
+test = {'entries': {'type': 'exp', 'lam': 0.5},
         'names': {'type': 'name'},
-        'salaries': {'type': 'norm', 'mean': 55000, 'stdev': 20000}}
+        'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
 
 res = sm.create(100, coltypes=test)
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,18 @@ addr|Faker address - random full addresses|
 date|Dates between begin and end.  If no begin/end are provided, default to the past year.|`begin=None`, `end=None`, `tzinfo=None`
 coords|Random tuples of floats from uniform 2D distribution|`lat_min=-90`, `lat_max=90`, `lon_min=-180`, `lon_max=180`
 uuid|Randomly selected UUIDs|
+categorical|Categorical values from a list of entries with optional weights|`entries=[1,2,3]`, `weights`
 faker|Custom faker field - see below|`provider`, `kwargs`
+
+For more information about a type, you can run:
+
+```python
+sm.help_type('exp')
+# This prints out the docstrings for the exponential distribution function, including any parameters
+
+sm.help_type()
+# This prints out the docstrings for all available types
+```
 
 We can also use the ColTypes class to create the coltypes dict with function calls:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To use the faker type, you have to pass the provider name and optional args like
 ```python
 faker_examples = {
         # same as fake.simple_profile(sex='F')
-        'names': {'type': 'name', 'provider': 'simple_profile', 'sex': 'F'},
+        'names': {'type': 'faker', 'provider': 'simple_profile', 'sex': 'F'},
         # same as fake.ipv6()
         'ips': {'type': 'faker', 'provider': 'ipv6'},
         # same as fake.job()

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-### Simulacrum
+# Simulacrum
+
 Simulacrum is a simple way to pass in a dictionary object, with column names and corresponding data types and output a pandas DataFrame of random data. This is great for creating a fake data set or testing a data science script whose validity through generalization needs to be tested. This is still a work in progress. Right now, numerical data can be made to fit a common statistical distribution so long as the proper statistical parameters are included with the type key in the dictionary.
 
-simulacrum fulfills the following use cases:
+Simulacrum fulfills the following use cases:
 - When data is needed for a tutorial, in order to train a model perfectly
 - When real data that is well understood cannot be gathered fast enough, but can be simulated quickly
-- to develop test case datasets for testing machine learning pipelines and applications on more generalizable data
-
+- To develop test case datasets for testing machine learning pipelines and applications on more generalizable data
 
 For instance, companies that operate primarily as brick and mortars cannot gather data at
 the same rate as ecommerce companies typically. Gathering customer data may take months. Therefore the data to develop machine learning applications may not exist at
@@ -22,14 +22,13 @@ $ pip install simulacrum
 ### Usage
 To create a fake pandas dataframe consisting of 100 rows. we would do the following:
 ```python
+>>> import simulacrum as sm
+>>> test = {'entries': {'type': 'exp', 'lam': 0.5},
+...        'names': {'type': 'name'},
+...        'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
 
-import simulacrum as sm
+>>> res = sm.create(100, coltypes=test)
 
-test = {'entries': {'type': 'exp', 'lam': 0.5},
-        'names': {'type': 'name'},
-        'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
-
-res = sm.create(100, coltypes=test)
 ```
 For the test variable which will be passed as coltypes, each key corresponds to the column name. Each value must be a dictionary
 with one key being type and then whatever statistical parameters if any correspond to that type. Please review source code to

--- a/README.md
+++ b/README.md
@@ -54,6 +54,27 @@ col_types.add_coltype('ips', 'faker', provider='ipv6')
 data_set = sm.create(1000, coltypes=col_types.get_coltypes())
 ```
 
+For a quick demonstration, if you don't specify any types a dataframe is created with one of each of the available types:
+
+```python
+import simulacrum as sm
+data_set = sm.create()
+list(df.iterrows())[0][1]
+#addr      55752 Clifford Crest Apt. 617\nBrownview, CA 7...
+#bin                                                      16
+#coords                      (-73.4784872076, 38.9711531723)
+#date                                    2017-02-15 20:42:52
+#exp                                                 2.45768
+#int                                                      88
+#name                                           Katelyn Tran
+#norm                                               -2.36078
+#num                                                0.150451
+#pois                                                      1
+#txt       Possimus voluptas similique vel. Veritatis fac...
+#uuid                   64db0551-9a36-4ab7-adc5-942016735f51
+#Name: 0, dtype: object
+```
+
 #### faker type:
 
 If you want to use other data types not allowed in simulacrum by default, you can use the `faker` type to use each data type provided by the awesome faker library.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To create a fake pandas dataframe consisting of 100 rows. we would do the follow
 
 import simulacrum as sm
 
-test = {'entries': {'type': 'exp', 'lam': 0.5},
+test = {'entries': {'type': 'exp', 'scale': 0.5},
         'names': {'type': 'name'},
-        'salaries': {'type': 'norm', 'mean': 55000, 'sd': 20000}}
+        'salaries': {'type': 'norm', 'mean': 55000, 'stdev': 20000}}
 
 res = sm.create(100, coltypes=test)
 ```
@@ -35,7 +35,7 @@ For the test variable which will be passed as coltypes, each key corresponds to 
 with one key being type and then whatever statistical parameters if any correspond to that type. Please review source code to
 see how to properly pass the correct keys and values. Possible types are as follows:
 
-`{'num': num_data, 'int': num_int, 'norm': norm_data, 'exp': exp_data, 'bin': binom_data, 'pois': poisson_data, 'txt': text_data, 'name': name_data, 'addr': address_data, 'zip': zip_data, 'uuid': uuid_data, 'faker': faker_data}`
+`{'num': num_data, 'int': num_int, 'norm': norm_data, 'exp': exp_data, 'bin': binom_data, 'pois': poisson_data, 'txt': text_data, 'name': name_data, 'addr': address_data, 'date': date_data, 'coords': coords_data, 'uuid': uuid_data, 'faker': faker_data}`
 
 Each key corresponds to a possible type, and the value is the function called in the source.
 
@@ -48,7 +48,7 @@ import simulacrum as sm
 col_types = sm.ColTypes()
 col_types.add_coltype('ids', 'uuid')
 col_types.add_coltype('name', 'name')
-col_types.add_coltype('salaries', 'norm', mean=50000, sd=1000)
+col_types.add_coltype('salaries', 'norm', mean=50000, stdev=1000)
 col_types.add_coltype('ips', 'faker', provider='ipv6')
 
 data_set = sm.create(1000, coltypes=col_types.get_coltypes())

--- a/simulacrum/__init__.py
+++ b/simulacrum/__init__.py
@@ -1,9 +1,2 @@
-import pandas as pd
-from faker import Faker
-import logging
-import numpy as np
-from datetime import datetime
-
-from .dataset import DataSet
-from .simdata import create
+from .dataset import *
 from .coltypes import ColTypes

--- a/simulacrum/__init__.py
+++ b/simulacrum/__init__.py
@@ -1,2 +1,2 @@
-from .dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS
+from .dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS, help_type
 from .coltypes import ColTypes

--- a/simulacrum/__init__.py
+++ b/simulacrum/__init__.py
@@ -1,2 +1,2 @@
-from .dataset import *
+from .dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS
 from .coltypes import ColTypes

--- a/simulacrum/coltypes.py
+++ b/simulacrum/coltypes.py
@@ -8,4 +8,3 @@ class ColTypes:
 
     def get_coltypes(self):
         return self.coltypes
- 

--- a/simulacrum/dataset.py
+++ b/simulacrum/dataset.py
@@ -1,185 +1,97 @@
-import pandas as pd
-from faker import Faker
-from uuid import uuid4
+"""Functions for generating random data."""
+
 import logging
-import numpy as np
-from datetime import datetime
+import pandas as pd
+
+from simulacrum import types
+
+TYPE_FUNCTIONS = {
+    'num': types.num_data,
+    'int': types.num_int,
+    'norm': types.norm_data,
+    'exp': types.exp_data,
+    'bin': types.binom_data,
+    'pois': types.poisson_data,
+    'txt': types.text_data,
+    'name': types.name_data,
+    'addr': types.address_data,
+    'date': types.date_data,
+    'coords': types.coords_data,
+    'uuid': types.uuid_data,
+    'faker': types.faker_data}
 
 
-class DataSet:
-    def __init__(self, length, **kwargs):
-        self.data = self.create(length, **kwargs)
+def create(length=100, cols=None, types=None, coltypes=None):
+    """Create a dataset based on passed in information.
 
-    def get_data(self):
-        return self.data
+    A user must either pass in cols and types lists, OR coltypes, OR the
+    function will default to "one of each" type.
 
-    def num_data(self, ty, length):
-        a = ty['min']
-        b = ty['max']
-        return pd.Series(np.random.uniform(a, b, length))
+    Parameters
+    ----------
+    length : int, optional
+        How many records (rows) in the returned dataframe
+    cols : list, optional
+        A list of column names
+    types : list of dict, optional
+        A list of "type dictionaries", defining both the type, and any
+        parameters to be passed to the type function.
+    coltypes : dict, optional
+        A combined version of cols and types, where the keys of the dictionary
+        are cols, and the values are type dictionaries.
+    """
+    if cols and types and coltypes:
+        raise ValueError(
+            'coltypes should not be defined when cols and types are defined')
+    elif cols is not None and types is not None:
+        column_iter = cols
+        type_iter = types
+        if len(column_iter) != len(type_iter):
+            raise ValueError(
+                'cols and types must be lists of equal length')
+    else:
+        if coltypes is None:
+            logging.warning('No coltypes specified, using default')
+            coltypes = default_coltypes()
+        column_iter = coltypes.keys()
+        type_iter = coltypes.values()
 
-    def num_int(self, ty, length):
-        a = ty['min']
-        b = ty['max']
-        return pd.Series(np.random.random_integers(a, b, length))
+    series_res = {}
+    for col, type_dict in zip(column_iter, type_iter):
+        validate_type_dict(type_dict)
+        data_builder = TYPE_FUNCTIONS[type_dict['type']]
+        del type_dict['type']
+        series_res[col] = data_builder(length, **type_dict)
 
-    def norm_data(self, ty, length):
-        if len(ty) == 1:
-            return pd.Series(np.random.standard_normal(size=length))
+    return pd.DataFrame(series_res)
 
-        mean = ty['mean']
-        sd = ty['sd']
-        return pd.Series(np.random.normal(mean, sd, length))
 
-    def exp_data(self, ty, length):
-        B = float(1) / float(ty['lam'])
-        return pd.Series(np.random.exponential(B, length))
+def validate_type_dict(type_dict):
+    """Validates a type dictionary
 
-    def binom_data(self, ty, length):
-        n = ty['n']
-        p = ty['p']
-        return pd.Series(np.random.binomial(n, p, length))
+    Parameters
+    ----------
+    type_dict : dict
+        Dictionary defining the type to be used for mocking data.
+    """
+    if "type" not in type_dict:
+        logging.error('Missing "type": %s', str(type_dict))
+        raise ValueError('"type" is a required key for all type dicts')
+    if type_dict['type'] not in TYPE_FUNCTIONS:
+        logging.error('Bad "type": %s', str(type_dict))
+        raise ValueError('"{}" is not a valid type'.format(type_dict['type']))
 
-    def poisson_data(self, ty, length):
-        lam = ty['lam']
-        return pd.Series(np.random.poisson(lam, length))
-
-    def text_data(self, ty, length):
-        res = []
-        f = Faker()
-        for _ in range(0, length - 1):
-            res.append(f.text())
-        return pd.Series(res)
-
-    def name_data(self, ty, length):
-        res = []
-        f = Faker()
-        for _ in range(0, length - 1):
-            res.append(f.name())
-        return pd.Series(res)
-
-    def cats_data(self, ty, length):
-        res = []
-        f = Faker()
-        for _ in range(0, length - 1):
-            res.append(f.name())
-        return pd.Series(res)
-
-    def date_data(self, ty, length):
-        # TODO add error handling and validation for date strings passed
-        res = []
-        f = Faker()
-        begin = datetime.strptime(ty['begin'], '%Y-%m-%d')
-        end = datetime.strptime(ty['end'], '%Y-%m-%d')
-        for _ in range(0, length - 1):
-            res.append(f.date_time_between_dates(datetime_start=begin,
-                                                 datetime_end=end))
-        return pd.Series(res)
-
-    def coords_data(self, ty, length):
-        lat_min = ty['lat_min']
-        lat_max = ty['lat_max']
-        lon_min = ty['lon_min']
-        lon_max = ty['lon_max']
-
-        if lat_min not in range(-90, 90) or lat_min > lat_max:
-            logging.error('lat ranges unacceptable; not in [-90, 90] or lat_min > lat_max')
-        if lon_min not in range(-180, 180) or lon_min > lon_max:
-            logging.error('lon ranges unacceptable; not in [-180, 180] or lon_min > lon_max')
-
-        return pd.Series(zip(np.random.uniform(lat_min, lat_max, length),
-                             np.random.uniform(lat_min, lat_max, length)))
-
-    def address_data(self, ty, length):
-        res = []
-        f = Faker()
-        for _ in range(0, length - 1):
-            res.append(f.address())
-        return pd.Series(res)
-
-    def zip_data(self, ty, length):
-        res = []
-        f = Faker()
-        for _ in range(0, length - 1):
-            res.append(f.name())
-        return pd.Series(res)
-
-    @staticmethod
-    def uuid_data(ty, length):
-        """
-        Generate a column of random uuids.
-
-        :param length: The number of uuids.
-        :type length: int.
-        :return: The column of uuids.
-        :rtype: pd.Series
-
-        """
-        return pd.Series(list(map(lambda _: uuid4(), range(length))))
-
-    @staticmethod
-    def faker_data(ty, length):
-        """
-        Generate a column based on any faker data type.
-
-        :param ty: A configuration for the faker data. Must contain faker provider and related args as dict.
-        :param length: The number of rows wanted.
-        :param ty: dict.
-        :param length: The number of rows wanted.
-        :type length: int.
-        :return: The column of Faker data.
-        :rtype: pd.Series
-
-        """
-        try:
-            provider = ty["provider"]
-            del ty["provider"]
-            return pd.Series(list(map(lambda _: getattr(Faker(), provider)(**ty), range(length))))
-        except KeyError:
-            raise KeyError("You have to define the Faker provider.")
-        except AttributeError:
-            raise AttributeError("Faker().{}() is not a valid Faker provider.".format(provider))
-
-    def create(self, length, cols=None, types=None, coltypes=None):
-        series_res = {}
-        ops = {'num': self.num_data,
-               'int': self.num_int,
-               'norm': self.norm_data,
-               'exp': self.exp_data,
-               'bin': self.binom_data,
-               'pois': self.poisson_data,
-               'txt': self.text_data,
-               'name': self.name_data,
-               'addr': self.address_data,
-               'zip': self.zip_data,
-               'date': self.date_data,
-               'uuid': self.uuid_data,
-               'faker': self.faker_data}
-
-        if cols and types and coltypes:
-            logging.error('coltypes should not be defined when cols and types are defined')
-
-        if (cols and not types) or (types and not cols):
-            logging.error('cols and types must both be defined together, as lists')
-
-        if (cols and types):
-            validate_types(types)
-            if len(cols) != len(types):
-                logging.error('cols and types must be lists of equal length')
-            for i in len(cols):
-                series_res[col[i]] = ops[types[i]['type']](types[i], length)
-
-        else:
-            if not coltypes:
-                logging.error('please define either cols and types or coltypes')
-            # Assure iteritems compatibility throught 2.7 and 3+
-            try:
-                coltypes_items = coltypes.iteritems()
-            except AttributeError:
-                coltypes_items = coltypes.items()
-            for col, typ in coltypes_items:
-                data_builder = ops[typ['type']]
-                del typ['type']
-                series_res[col] = data_builder(typ, length)
-
-        return pd.DataFrame(series_res)
+def default_coltypes():
+    """Sets up the default column types
+    
+    Returns
+    -------
+    dict
+        A dictionary that can be passed in to coltypes in create function,
+        which just creates one column of each type in TYPE_FUNCTIONS
+    """
+    coltypes = {}
+    for key in TYPE_FUNCTIONS:
+        if key != 'faker':
+            coltypes[key] = {'type': key}
+    return coltypes

--- a/simulacrum/dataset.py
+++ b/simulacrum/dataset.py
@@ -18,8 +18,17 @@ TYPE_FUNCTIONS = {
     'date': sim_types.date_data,
     'coords': sim_types.coords_data,
     'uuid': sim_types.uuid_data,
+    'categorical': sim_types.categorical_data,
     'faker': sim_types.faker_data}
 
+def help_type(function_name=None):
+    to_print = TYPE_FUNCTIONS.items()
+    if function_name:
+        to_print = [(function_name, TYPE_FUNCTIONS[function_name])]
+    for function_name, function in to_print:
+        print(
+            'Name: {}, Function: simulacrum.types.{}'.format(function_name, function.__name__))
+        print(function.__doc__ + '\n')
 
 def create(length=100, cols=None, types=None, coltypes=None, null_rate=0):
     """Create a dataset based on passed in information.

--- a/simulacrum/dataset.py
+++ b/simulacrum/dataset.py
@@ -1,4 +1,4 @@
-"""Functions for generating random data."""
+"""Functions for creating a dataframe based on setup dictionaries"""
 
 import logging
 import pandas as pd

--- a/simulacrum/simdata.py
+++ b/simulacrum/simdata.py
@@ -1,5 +1,0 @@
-from .dataset import DataSet
-
-def create(length, **kwargs):
-    x = DataSet(length, **kwargs)
-    return x.data

--- a/simulacrum/types.py
+++ b/simulacrum/types.py
@@ -2,7 +2,6 @@
 
 from uuid import uuid4
 import logging
-import sys
 import datetime
 import numpy as np
 import pandas as pd

--- a/simulacrum/types.py
+++ b/simulacrum/types.py
@@ -1,3 +1,5 @@
+"""Functions for generating random data."""
+
 from uuid import uuid4
 import logging
 import sys

--- a/simulacrum/types.py
+++ b/simulacrum/types.py
@@ -1,0 +1,99 @@
+from uuid import uuid4
+import logging
+import sys
+import datetime
+import numpy as np
+import pandas as pd
+from faker import Faker
+
+FAKE = Faker()
+
+def name_data(length):
+    """Faker names series"""
+    return pd.Series([FAKE.name() for _ in range(length)])
+
+def text_data(length, max_nb_chars=200):
+    """Faker text series"""
+    return pd.Series([FAKE.text(max_nb_chars) for _ in range(length)])
+
+def address_data(length):
+    """Faker address series"""
+    return pd.Series([FAKE.address() for _ in range(length)])
+
+def num_data(length, minimum=0, maximum=1):
+    """Uniform distribution"""
+    return pd.Series(np.random.uniform(minimum, maximum, length))
+
+def num_int(length, minimum=0, maximum=100):
+    """Random integers"""
+    return pd.Series(np.random.random_integers(minimum, maximum, length))
+
+def norm_data(length, mean=0, stdev=1):
+    """Normal distribution data"""
+    return pd.Series(np.random.normal(mean, stdev, length))
+
+def exp_data(length, scale=1.0):
+    """Exponential distribution data"""
+    return pd.Series(np.random.exponential(scale, length))
+
+def binom_data(length, n=100, p=0.1):
+    """Binomial distribution data"""
+    return pd.Series(np.random.binomial(n, p, length))
+
+def poisson_data(length, lam=1.0):
+    return pd.Series(np.random.poisson(lam, length))
+
+def date_data(length, datetime_start=None, datetime_end=None, tzinfo=None):
+    """dates between a start and end.  If no start and end are provided,
+    default to one year ago and today."""
+    if datetime_start is None and datetime_end is None:
+        datetime_end = datetime.datetime.now()
+        datetime_start = datetime_end - datetime.timedelta(365)
+    return pd.Series(
+        [FAKE.date_time_between_dates(
+            datetime_start, datetime_end, tzinfo) for _ in range(length)])
+
+def coords_data(length, lat_min=-90, lat_max=90, lon_min=-180, lon_max=180):
+    """Geographic coordinates"""
+    if lat_min < -90 or lat_max > 90 or lat_min > lat_max:
+        raise ValueError(
+            'lat ranges unacceptable; not in [-90, 90] or lat_min > lat_max')
+    if lon_min < -180 or lon_max > 180 or lon_min > lon_max:
+        raise ValueError(
+            'lon ranges unacceptable; not in [-180, 180] or lon_min > lon_max')
+    return pd.Series(list(zip(np.random.uniform(lat_min, lat_max, length),
+                         np.random.uniform(lat_min, lat_max, length))))
+
+def uuid_data(length):
+    """
+    Generate a column of random uuids.
+
+    :param length: The number of uuids.
+    :type length: int.
+    :return: The column of uuids.
+    :rtype: pd.Series
+
+    """
+    return pd.Series(list(map(lambda _: uuid4(), range(length))))
+
+
+def faker_data(length, **kwargs):
+    """
+    Generate a column based on any faker data type.
+
+    :param kwargs: A configuration for the faker data. Must contain faker provider and related args as dict.
+    :param length: The number of rows wanted.
+    :type length: int.
+    :return: The column of Faker data.
+    :rtype: pd.Series
+
+    """
+    try:
+        provider = kwargs["provider"]
+        del kwargs["provider"]
+        return pd.Series(list(map(
+            lambda _: getattr(FAKE, provider)(**kwargs), range(length))))
+    except KeyError:
+        raise KeyError("You have to define the Faker provider.")
+    except AttributeError:
+        raise AttributeError("Faker().{}() is not a valid Faker provider.".format(provider))

--- a/simulacrum/types.py
+++ b/simulacrum/types.py
@@ -15,7 +15,15 @@ def name_data(length):
     return pd.Series([FAKE.name() for _ in range(length)])
 
 def text_data(length, max_nb_chars=200):
-    """Faker text series"""
+    """Faker text series
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    max_nb_chars : int, optional
+        Maximum number of characters in the text data, defaults to 200
+    """
     return pd.Series([FAKE.text(max_nb_chars) for _ in range(length)])
 
 def address_data(length):
@@ -23,15 +31,45 @@ def address_data(length):
     return pd.Series([FAKE.address() for _ in range(length)])
 
 def num_data(length, min=0, max=1):
-    """Uniform distribution"""
+    """Uniform distribution
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    min : numeric, optional
+        Minimum value, defaults to 0
+    max : numeric, optional
+        Maximum value, defaults to 1
+    """
     return pd.Series(np.random.uniform(min, max, length))
 
 def num_int(length, min=0, max=100):
-    """Random integers"""
+    """Random integers
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    min : int, optional
+        Minimum value, defaults to 0
+    max : int, optional
+        Maximum value, defaults to 100
+    """
     return pd.Series(np.random.random_integers(min, max, length))
 
 def norm_data(length, mean=0, sd=1):
-    """Normal distribution data"""
+    """Normal distribution data
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    mean : numeric, optional
+        Mean of the normal distribution, defaults to 0
+    sd : numeric, optional
+        Standard deviation of the distribution, defaults to 1
+    """
     return pd.Series(np.random.normal(mean, sd, length))
 
 def exp_data(length, lam=1.0):
@@ -40,10 +78,29 @@ def exp_data(length, lam=1.0):
     return pd.Series(np.random.exponential(scale, length))
 
 def binom_data(length, n=100, p=0.1):
-    """Binomial distribution data"""
+    """Binomial distribution data
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    n : int, optional
+        Optional number of experiments, defaults to 100
+    p : float, optional
+        Probability of a successful experiment, defaults to 0.1
+    """
     return pd.Series(np.random.binomial(n, p, length))
 
 def poisson_data(length, lam=1.0):
+    """Poisson distribution data
+
+    Parameters
+    ----------
+    length : int
+        Length of the returned Series
+    lam : float, optional
+        Expectation of interval
+    """
     return pd.Series(np.random.poisson(lam, length))
 
 def date_data(length, begin=None, end=None, tzinfo=None):
@@ -80,7 +137,7 @@ def date_data(length, begin=None, end=None, tzinfo=None):
 
 def coords_data(length, lat_min=-90, lat_max=90, lon_min=-180, lon_max=180):
     """Randomly-selected geographic coordinates
-    
+
     Parameters
     ----------
     length : int
@@ -110,7 +167,7 @@ def uuid_data(length):
     ----------
     length : int
         Length of the series
-    
+
     Returns
     -------
     pandas.Series
@@ -127,7 +184,7 @@ def faker_data(length, **kwargs):
     length : int
         Length of the series to return
     kwargs : dict
-        A configuration for the faker data. Must contain at least provider () and related args as
+        A configuration for the faker data. Must contain at least provider and related args as
         dict.
 
     Returns
@@ -145,10 +202,31 @@ def faker_data(length, **kwargs):
     return pd.Series(map(lambda _: func(**kwargs), range(length)))
 
 
+def categorical_data(length, elements=[1,2,3], weights=None):
+    """Generate a categorical field based on a list of values and optional weights
+
+    Parameters
+    ----------
+    length : int
+        Length of the series
+    elements : list, optional
+        List of values to be selected from.  Defaults to [1,2,3] for argument's sake
+    weights : list, optional
+        Optional list of numeric weights.  Must be the same length as values.  If not provided,
+        equal weights will be given to all categories.
+
+    Returns
+    -------
+    pandas.Series
+        Randomly selected categorical variables.
+    """
+    return pd.Series(np.random.choice(elements, size=length, p=weights), dtype='category')
+
+
 def null_mask(length, type_function, null_rate=0, **kwargs):
     """Masks out a random subset of series values with Numpy nulls (np.nan).  The number of null
     values will be int(null_rate * length)
-    
+
     Parameters
     ----------
     type_function : function

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from simulacrum.dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS
+from simulacrum.dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS, help_type
 
 def test_validate_type_dict():
     for value in ('num','int','norm','exp','bin','pois','txt','name','addr',
@@ -61,3 +61,7 @@ def test_create_passthrough_bad_params():
                 'int': {'type': 'int', 'min': 10, 'bad_param': -999},
                 'txt': {'type': 'txt', 'max_nb_chars': 20}
                 })
+
+def test_help_type():
+    #Just call it to make sure it's working
+    help_type()

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -51,3 +51,13 @@ def test_create_passthrough_params():
     assert test_df['int'].max() <= 100
     lengths = test_df['txt'].apply(lambda x: len(x))
     assert lengths.max() <= 20
+
+
+def test_create_passthrough_bad_params():
+    with pytest.raises(TypeError):
+        test_df = create(
+            length=1000,
+            coltypes={
+                'int': {'type': 'int', 'minimum': 10, 'bad_param': -999},
+                'txt': {'type': 'txt', 'max_nb_chars': 20}
+                })

--- a/tests/dataset_test.py
+++ b/tests/dataset_test.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from simulacrum.dataset import *
+from simulacrum.dataset import create, validate_type_dict, default_coltypes, TYPE_FUNCTIONS
 
 def test_validate_type_dict():
     for value in ('num','int','norm','exp','bin','pois','txt','name','addr',
@@ -42,7 +42,7 @@ def test_create_passthrough_params():
     test_df = create(
         length=1000,
         coltypes={
-            'int': {'type': 'int', 'minimum': 10},
+            'int': {'type': 'int', 'min': 10},
             'txt': {'type': 'txt', 'max_nb_chars': 20}
             })
     assert len(test_df) == 1000
@@ -58,6 +58,6 @@ def test_create_passthrough_bad_params():
         test_df = create(
             length=1000,
             coltypes={
-                'int': {'type': 'int', 'minimum': 10, 'bad_param': -999},
+                'int': {'type': 'int', 'min': 10, 'bad_param': -999},
                 'txt': {'type': 'txt', 'max_nb_chars': 20}
                 })

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -1,0 +1,124 @@
+import datetime
+import pytest
+from uuid import UUID
+from functools import reduce
+import numpy as np
+
+from simulacrum import types
+from simulacrum import dataset
+
+def _default_test(listToCheck, typeToWait, length):
+    return len(listToCheck) == length\
+        and reduce(lambda p, n: p and type(n) == typeToWait, listToCheck, True)
+
+def test_uuid_data():
+    """Test uuid data."""
+    uuids_list = types.uuid_data(30)
+    assert _default_test(uuids_list, UUID, 30)\
+        and len(set(uuids_list)) == len(uuids_list)
+
+def test_faker_data_ipv6():
+    """Test faker data."""
+    ipv6_list = types.faker_data(**{
+        "provider": "ipv6",
+        "network": False
+    }, length=23)
+    random_element_list = types.faker_data(**{
+        "provider": "random_element",
+        "elements": ('a', 'b', 'c', 'd'),
+    }, length=13)
+    assert _default_test(ipv6_list, str, 23)\
+        and _default_test(random_element_list, str, 13)\
+        and reduce(lambda p, n: p and n in ['a', 'b', 'c', 'd'], random_element_list, True)
+
+def test_name_data():
+    names = types.name_data(10)
+    assert len(names) == 10
+    assert names.dtype == np.dtype('O')
+    for item in names:
+        assert isinstance(item, str)
+
+def test_text_data():
+    text = types.text_data(10)
+    assert len(text) == 10
+    assert text.dtype == np.dtype('O')
+    for item in text:
+        assert isinstance(item, str)
+    text_max_10 = types.text_data(10, 10)
+    assert len(text_max_10) == 10
+    lengths = text_max_10.apply(lambda x: len(x))
+    assert lengths.max() <= 10
+
+def test_address_data():
+    addresses = types.address_data(10)
+    assert len(addresses) == 10
+    assert addresses.dtype == np.dtype('O')
+    for item in addresses:
+        assert isinstance(item, str)
+
+def test_num_data():
+    nums = types.num_data(1000, minimum=0, maximum=1)
+    assert len(nums) == 1000
+    assert nums.max() <= 1
+    assert nums.min() >= 0
+    assert nums.dtype == np.dtype('float')
+
+def test_num_int():
+    nums = types.num_int(1000, minimum=0, maximum=100)
+    assert len(nums) == 1000
+    assert nums.max() <= 100
+    assert nums.min() >= 0
+    assert nums.dtype == np.dtype('int')
+
+def test_norm_data():
+    nums = types.norm_data(1000, mean=0, stdev=100)
+    assert len(nums) == 1000
+    assert nums.dtype == np.dtype('float')
+
+def test_exp_data():
+    nums = types.exp_data(1000, scale=10)
+    assert len(nums) == 1000
+    assert nums.dtype == np.dtype('float')
+    assert nums.max() >= 0
+
+def test_binom_data():
+    nums = types.binom_data(10)
+    assert len(nums) == 10
+    assert nums.dtype == np.dtype('int')
+
+def test_poisson_data():
+    nums = types.poisson_data(10)
+    assert len(nums) == 10
+    assert nums.dtype == np.dtype('int')
+
+def test_date_data():
+    dates = types.date_data(length=1000)
+    assert len(dates) == 1000
+    assert len(dates.unique()) > 1
+    assert dates.dtype == np.dtype('<M8[ns]')
+    
+def test_date_data_between():
+    dates = types.date_data(
+        length=1000,
+        datetime_start=datetime.datetime(2000, 1, 1),
+        datetime_end=datetime.datetime(2000, 12, 31))
+    assert len(dates) == 1000
+    assert len(dates.unique()) > 1
+    assert dates.min() >= datetime.datetime(2000, 1, 1)
+    assert dates.max() < datetime.datetime(2001, 1, 1)
+    assert dates.dtype == np.dtype('<M8[ns]')
+
+def test_coords_data():
+    coords = types.coords_data(10)
+    assert len(coords) == 10
+    assert coords.dtype == np.dtype('O')
+    for item in coords:
+        assert isinstance(item, tuple)
+    with pytest.raises(ValueError):
+        coords = types.coords_data(10, lat_min=-91)
+    with pytest.raises(ValueError):
+        coords = types.coords_data(10, lat_max=91)
+    with pytest.raises(ValueError):
+        coords = types.coords_data(10, lon_min=-181)
+    with pytest.raises(ValueError):
+        coords = types.coords_data(10, lon_max=181)

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -48,6 +48,8 @@ def test_text_data():
     assert len(text_max_10) == 10
     lengths = text_max_10.apply(lambda x: len(x))
     assert lengths.max() <= 10
+    with pytest.raises(TypeError):
+        text = types.text_data(10, bad_param=100)
 
 def test_address_data():
     addresses = types.address_data(10)
@@ -55,6 +57,8 @@ def test_address_data():
     assert addresses.dtype == np.dtype('O')
     for item in addresses:
         assert isinstance(item, str)
+    with pytest.raises(TypeError):
+        addresses = types.address_data(10, bad_param=100)
 
 def test_num_data():
     nums = types.num_data(1000, minimum=0, maximum=1)
@@ -62,6 +66,8 @@ def test_num_data():
     assert nums.max() <= 1
     assert nums.min() >= 0
     assert nums.dtype == np.dtype('float')
+    with pytest.raises(TypeError):
+        nums = types.num_data(10, minimum=0, bad_param=100)
 
 def test_num_int():
     nums = types.num_int(1000, minimum=0, maximum=100)

--- a/tests/types_test.py
+++ b/tests/types_test.py
@@ -77,12 +77,12 @@ def test_num_int():
     assert nums.dtype == np.dtype('int')
 
 def test_norm_data():
-    nums = types.norm_data(1000, mean=0, stdev=100)
+    nums = types.norm_data(1000, mean=0, sd=100)
     assert len(nums) == 1000
     assert nums.dtype == np.dtype('float')
 
 def test_exp_data():
-    nums = types.exp_data(1000, scale=10)
+    nums = types.exp_data(1000, lam=10)
     assert len(nums) == 1000
     assert nums.dtype == np.dtype('float')
     assert nums.max() >= 0
@@ -106,13 +106,46 @@ def test_date_data():
 def test_date_data_between():
     dates = types.date_data(
         length=1000,
-        datetime_start=datetime.datetime(2000, 1, 1),
-        datetime_end=datetime.datetime(2000, 12, 31))
+        begin=datetime.datetime(2000, 1, 1),
+        end=datetime.datetime(2000, 12, 31))
     assert len(dates) == 1000
     assert len(dates.unique()) > 1
     assert dates.min() >= datetime.datetime(2000, 1, 1)
     assert dates.max() < datetime.datetime(2001, 1, 1)
     assert dates.dtype == np.dtype('<M8[ns]')
+    dates = types.date_data(
+        length=1000,
+        begin=datetime.date(2000, 1, 1),
+        end=datetime.date(2000, 12, 31))
+    assert len(dates) == 1000
+    assert len(dates.unique()) > 1
+    assert dates.min() >= datetime.datetime(2000, 1, 1)
+    assert dates.max() < datetime.datetime(2001, 1, 1)
+    assert dates.dtype == np.dtype('<M8[ns]')
+
+def test_date_data_between_text():
+    dates = types.date_data(
+        length=1000,
+        begin='2017-01-01',
+        end='2017-05-31')
+    assert len(dates) == 1000
+    assert len(dates.unique()) > 1
+    assert dates.min() >= datetime.datetime(2017, 1, 1)
+    assert dates.max() < datetime.datetime(2017, 6, 1)
+    assert dates.dtype == np.dtype('<M8[ns]')
+
+def test_date_data_bad_calls():
+    with pytest.raises(ValueError):
+        dates = types.date_data(length=10, begin='217-01-01', end='217-05-31')
+    with pytest.raises(ValueError):
+        dates = types.date_data(length=1000, begin='2017-01-01')
+    with pytest.raises(ValueError):
+        dates = types.date_data(length=1000, begin=datetime.date(2000, 1, 1))
+    with pytest.raises(ValueError):
+        dates = types.date_data(length=1000, end='2017-01-01')
+    with pytest.raises(ValueError):
+        dates = types.date_data(length=1000, end=datetime.date(2000, 1, 1))
+
 
 def test_coords_data():
     coords = types.coords_data(10)


### PR DESCRIPTION
Hi @jbrambleDC, came across your package when I was thinking about building something similar, so thanks for that!

There were a couple of things broken when I was poking around with the code (text-based types were only populating `n-1` records for one) and one thing lead to another and I wound up refactoring and adding some testing.  `python -m pytest` runs the tests.

Are you interested in merging these changes up into your repo/package?  If not feel free to close the PR and I'll just keep it on a fork - don't want to step on any toes :).  I've got a couple other things I was thinking of supporting, specifying null/missing rates being a big one that crops up in my day job.

One breaking change I made was switching the calling pattern of the individual type functions to expose them as parameters to the function instead of just passing the `ty` dictionary.  `num_int` for example:

```python
def num_int(self, ty, length):
    a = ty['min']
    b = ty['max']
    return pd.Series(np.random.random_integers(a, b, length))
```

vs.

```python
def num_int(length, minimum=0, maximum=100):
    """Random integers"""
    return pd.Series(np.random.random_integers(minimum, maximum, length))
```

Makes things more explicit imho, and the functions are split out of the class for easier testing.